### PR TITLE
The regex to find tha tablets affected is broken, Fixing this to obta…

### DIFF
--- a/analyzer_dict.py
+++ b/analyzer_dict.py
@@ -47,7 +47,15 @@ solutions = {
 **Useful Commands**:  
     - Get the list of tablets hitting this issue.  
     ```
-    grep "operation memory consumption" logfile| awk '{print "T:", $6, "P:", $8}' | sort | uniq
+    This sorts the tablet IDs and removes duplicates, providing you with a list of unique tablet IDs.
+
+    zgrep -o -E 'tablet: [a-f0-9]+' <log file name> | awk '{print $2}' | sort -u
+
+    You can also do something like:
+
+    This will just count the uniq tablets affected and show the count ob tablets. 
+
+    zgrep -o -E 'tablet: [a-f0-9]+' <log file name> | awk '{print $2}' | sort | uniq -c 
     ```
 """,
 "Too big clock skew is detected": """This error indicates the nodes running tserver/master process are having clock skew outside of an acceptable range. Clock skew and clock drift can lead to significant consistency issues and should be fixed as soon as possible.  


### PR DESCRIPTION
We might need to figure out and improve this regex. The sample messages is:

```
W0121 00:26:05.016111 78981 process_context.cc:185] SQL Error: Execution Error. Write(tablet: 430c914f896a470d903acd897b206151, num_ops: 1, num_attempts: 46, txn: 00000000-0000-0000-0000-000000000000, subtxn: [none]) passed its deadline 13636561.025s (passed: 65.433s): Remote error (yb/rpc/outbound_call.cc:410): Service unavailable (yb/tablet/operations/operation_tracker.cc:167): Operation failed, tablet 430c914f896a470d903acd897b206151 operation memory consumption (1073741588) has exceeded its limit (1073741824) or the limit of an ancestral tracker (rpc error 4)
```

Now if we run the regex as stated in the code.

```
support@lincoln:/cases/8832/2024-01-21T10_05_51/support_bundle_2024-01-22-03-46-48/yb-support-bundle-gamma-prod-20240121062954.393-logs/universe_logs/tserver/logs$ zgrep "operation memory consumption" yb-tserver.ip-.us-west-2.aws.plumenet.io.yugabyte.log.INFO.20240120-235824.78970.gz| awk '{print "T:", $6, "P:", $8}' | sort | uniq
T: Error: P: Error.
T: out P: Failed
support@lincoln:/cases/8832/2024-01-21T10_05_51/support_bundle_2024-01-22-03-46-48/yb-support-bundle-gamma-prod-20240121062954.393-logs/universe_logs/tserver/logs$ zgrep "operation memory consumption" yb-tserver.ip.us-west-2.aws.plumenet.io.yugabyte.log.INFO.20240120-235824.78970.gz| awk '{print "T:", $6, "P:", $8}'
T: out P: Failed
```

**The fix would be below:**

```
support@lincoln:/cases/8832/2024-01-21T10_05_51/support_bundle_2024-01-22-03-46-48/yb-support-bundle-gamma-prod-20240121062954.393-logs/universe_logs/tserver/logs$ zgrep -o -E 'tablet: [a-f0-9]+' yb-tserver.ip.us-west-2.aws.plumenet.io.yugabyte.log.INFO.20240120-235824.78970.gz | awk '{print $2}' | sort | uniq -c
      2 013d34c7f28a4f0d94e7d39eced5404a
      1 01d49a1fa7fc4cafa82ef3175cf3209c
```
