### PR TITLE
Make the universe DB version search faster as it's costing huge time

### DIFF
--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -431,7 +431,13 @@ def getVersion():
         else:
             logs = open(file, "r")
         try:
-            lines = logs.readlines()[:10]
+            lines = []
+            # Read up to 10 lines efficiently
+            for i in range(10):
+                line = logs.readline()
+                if not line:
+                    break
+                lines.append(line)
         except UnicodeDecodeError as e:
             logger.warning("Skipping file {} as it is not a text file".format(file))
             continue


### PR DESCRIPTION
**Problem:** A bundle extraction started at :
```
2024-06-18 04:09:28,331:INFO:- Start Time: 0611 04:09
.
.
2024-06-18 04:10:05,568:INFO:- Number of files to analyze:144
Finished at:
2024-06-18 05:59:44,402:INFO:- Analysis complete. Results are in 2024-06-18-04-09-28_analysis.html
```

This is very huge time spent, however the bundle size is not that big.
```
-rwxrwx---  1 gunicorn support 2.6G Jun 17 22:44 yb-support-bundle-ybu-p01-bpay-20240617205953.260-logs.tar.gz
```

In the original code, `logs.readlines()[:10]` reads all lines of the file first into memory and then reads the first line. This is inefficient for very large files and many files as loading in memory will take time.

I changed this to read up to 10 lines in a more memory-efficient manner, reading line-by-line using a loop.

**Testing Results**:

For the same bundle the extraction starts at:

```
time yb-log-analyzer-py-0.1.0/log_analyzer.py -l yb-support-bundle-ybu-p01-bpay-20240617205953.260-logs.tar.gz
2024-06-21 07:51:27,595:INFO:- Start Time: 1900-06-14 07:51:00
2024-06-21 07:51:27,596:INFO:- End Time: None
.
.
.
2024-06-21 08:24:07,575:INFO:- Finished analyzing file yb-support-bundle-ybu-p01-bpay-20240617205953.260-logs/yb-prod-ybu-p01-bpay-n6/tserver/logs/yb-tserver.danpvby00001.yugabyte.log.INFO.20240615-141658.4465.gz
2024-06-21 08:24:08,123:INFO:- Analysis complete. Results are in 2024-06-21-07-51-27_analysis.html
2024-06-21 08:24:08,134:INFO:- ⌘+Click 👉👉 http://lincoln:7777/10188-2024-06-21-07-51-27_analysis.html

real	32m40.686s
user	32m4.522s
sys	0m32.725s
```

So this is 2x faster then previous run. 